### PR TITLE
feat: optimize cuda for vapoursynth

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,4 +16,4 @@ build:
 .PHONY: vs
 vs:
 	rm -f encoded.mkv
-	vspipe -c y4m example/vapourSynth.py - | ffmpeg -i - -vcodec libx265 -crf 16 encoded.mkv
+	vspipe -c y4m example/vapoursynth.py - | ffmpeg -i - -vcodec libx265 -crf 16 encoded.mkv

--- a/README.md
+++ b/README.md
@@ -30,7 +30,9 @@ import numpy as np
 
 from ccrestoration import AutoModel, ConfigType, SRBaseModel
 
-model: SRBaseModel = AutoModel.from_pretrained(ConfigType.RealESRGAN_APISR_RRDB_GAN_generator_2x)
+model: SRBaseModel = AutoModel.from_pretrained(
+    pretrained_model_name=ConfigType.RealESRGAN_APISR_RRDB_GAN_generator_2x,
+)
 
 img = cv2.imdecode(np.fromfile("test.jpg", dtype=np.uint8), cv2.IMREAD_COLOR)
 img = model.inference_image(img)
@@ -48,7 +50,8 @@ from vapoursynth import core
 from ccrestoration import AutoModel, BaseModelInterface, ConfigType
 
 model: BaseModelInterface = AutoModel.from_pretrained(
-    pretrained_model_name=ConfigType.AnimeSR_v2_4x
+    pretrained_model_name=ConfigType.RealESRGAN_AnimeJaNai_HD_V3_Compact_2x,
+    tile=None
 )
 
 clip = core.bs.VideoSource(source="s.mp4")

--- a/ccrestoration/model/vsr_base_model.py
+++ b/ccrestoration/model/vsr_base_model.py
@@ -82,15 +82,15 @@ class VSRBaseModel(SRBaseModel):
         :return:
         """
 
-        from ccrestoration.vs import inference_vsr, inference_vsr_one_frame_out
+        from ccrestoration.vs import inference_vsr
 
         cfg: BaseConfig = self.config
 
-        if self.one_frame_out:
-            return inference_vsr_one_frame_out(
-                inference=self.inference, clip=clip, scale=cfg.scale, length=cfg.length, device=self.device
-            )
-        else:
-            return inference_vsr(
-                inference=self.inference, clip=clip, scale=cfg.scale, length=cfg.length, device=self.device
-            )
+        return inference_vsr(
+            inference=self.inference,
+            clip=clip,
+            scale=cfg.scale,
+            length=cfg.length,
+            device=self.device,
+            one_frame_out=self.one_frame_out,
+        )

--- a/ccrestoration/vs/__init__.py
+++ b/ccrestoration/vs/__init__.py
@@ -1,9 +1,38 @@
 """
 All the vs functions are referenced from HolyWu's repository: https://github.com/HolyWu
 Thanks to HolyWu for his great work on super-resolution.
+
+BSD 3-Clause License
+
+Copyright (c) 2021, HolyWu
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 """
 
 
 from ccrestoration.vs.sr import inference_sr  # noqa
-from ccrestoration.vs.convert import tensor_to_frame, frame_to_tensor  # noqa
-from ccrestoration.vs.vsr import inference_vsr, inference_vsr_one_frame_out  # noqa
+from ccrestoration.vs.vsr import inference_vsr  # noqa

--- a/ccrestoration/vs/sr.py
+++ b/ccrestoration/vs/sr.py
@@ -1,3 +1,10 @@
+"""
+Reference: https://github.com/HolyWu/vs-realesrgan
+
+Thanks to HolyWu for his great work on super-resolution.
+"""
+
+from threading import Lock
 from typing import Any, Callable, Union
 
 import torch
@@ -11,8 +18,6 @@ def inference_sr(
     clip: vs.VideoNode,
     scale: Union[float, int, Any],
     device: torch.device,
-    _frame_to_tensor: Callable[[vs.VideoFrame, torch.device], torch.Tensor] = frame_to_tensor,
-    _tensor_to_frame: Callable[[torch.Tensor, vs.VideoFrame], vs.VideoFrame] = tensor_to_frame,
 ) -> vs.VideoNode:
     """
     Inference the video with the model, the clip should be a vapoursynth clip
@@ -21,20 +26,94 @@ def inference_sr(
     :param clip: vs.VideoNode
     :param scale: The scale factor
     :param device: The device
-    :param _frame_to_tensor: The function to convert the frame to tensor
-    :param _tensor_to_frame: The function to convert the tensor to frame
     :return:
     """
 
     if clip.format.id not in [vs.RGBH, vs.RGBS]:
         raise vs.Error("Only vs.RGBH and vs.RGBS formats are supported")
 
+    if device.type == torch.device("cuda").type:
+        return inference_sr_cuda(inference, clip, scale, device)
+    else:
+        return inference_sr_general(inference, clip, scale, device)
+
+
+def inference_sr_general(
+    inference: Callable[[torch.Tensor], torch.Tensor],
+    clip: vs.VideoNode,
+    scale: Union[float, int, Any],
+    device: torch.device,
+) -> vs.VideoNode:
+    """
+    Inference for General devices
+
+    :param inference: The inference function
+    :param clip: vs.VideoNode
+    :param scale: The scale factor
+    :param device: The device
+    :return:
+    """
+
+    f2t_stream_lock = Lock()
+    inf_stream_lock = Lock()
+    t2f_stream_lock = Lock()
+
     def _inference(n: int, f: list[vs.VideoFrame]) -> vs.VideoFrame:
-        img = _frame_to_tensor(f[0], device).unsqueeze(0)
+        with f2t_stream_lock:
+            img = frame_to_tensor(f[0], device).unsqueeze(0)
 
-        output = inference(img)
+        with inf_stream_lock:
+            output = inference(img)
 
-        return _tensor_to_frame(output, f[1].copy())
+        with t2f_stream_lock:
+            res = tensor_to_frame(output, f[1].copy())
+
+        return res
+
+    new_clip = clip.std.BlankClip(width=clip.width * scale, height=clip.height * scale, keep=True)
+    return new_clip.std.FrameEval(
+        lambda n: new_clip.std.ModifyFrame([clip, new_clip], _inference), clip_src=[clip, new_clip]
+    )
+
+
+def inference_sr_cuda(
+    inference: Callable[[torch.Tensor], torch.Tensor],
+    clip: vs.VideoNode,
+    scale: Union[float, int, Any],
+    device: torch.device,
+) -> vs.VideoNode:
+    """
+    Inference for CUDA devices
+
+    :param inference: The inference function
+    :param clip: vs.VideoNode
+    :param scale: The scale factor
+    :param device: The device
+    :return:
+    """
+
+    f2t_stream_lock = Lock()
+    inf_stream_lock = Lock()
+    t2f_stream_lock = Lock()
+
+    f2t_stream = torch.cuda.Stream(device)
+    inf_stream = torch.cuda.Stream(device)
+    t2f_stream = torch.cuda.Stream(device)
+
+    def _inference(n: int, f: list[vs.VideoFrame]) -> vs.VideoFrame:
+        with f2t_stream_lock, torch.cuda.stream(f2t_stream):
+            img = frame_to_tensor(f[0], device).unsqueeze(0)
+            f2t_stream.synchronize()
+
+        with inf_stream_lock, torch.cuda.stream(inf_stream):
+            output = inference(img)
+            inf_stream.synchronize()
+
+        with t2f_stream_lock, torch.cuda.stream(t2f_stream):
+            res = tensor_to_frame(output, f[1].copy())
+            t2f_stream.synchronize()
+
+        return res
 
     new_clip = clip.std.BlankClip(width=clip.width * scale, height=clip.height * scale, keep=True)
     return new_clip.std.FrameEval(

--- a/example/vapoursynth.py
+++ b/example/vapoursynth.py
@@ -11,7 +11,7 @@ from ccrestoration import AutoModel, BaseModelInterface, ConfigType
 # --- sisr, use fp16 to inference (vs.RGBH)
 
 model: BaseModelInterface = AutoModel.from_pretrained(
-    pretrained_model_name=ConfigType.RealESRGAN_AnimeJaNai_HD_V3_Compact_2x
+    pretrained_model_name=ConfigType.RealESRGAN_AnimeJaNai_HD_V3_Compact_2x, tile=None
 )
 
 clip = core.bs.VideoSource(source="s.mp4")
@@ -25,6 +25,7 @@ clip.set_output()
 # model: BaseModelInterface = AutoModel.from_pretrained(
 #     pretrained_model_name=ConfigType.RealESRGAN_AnimeJaNai_HD_V3_Compact_2x,
 #     fp16=False,
+#     tile=None
 # )
 #
 # clip = core.bs.VideoSource(source="s.mp4")


### PR DESCRIPTION
https://github.com/TensoRaws/ccrestoration/issues/21

## Summary by Sourcery

Optimize VapourSynth by introducing separate inference functions for multi-frame and one-frame output models and enhancing CUDA support. Update documentation to reflect these changes and fix a typo in the Makefile.

New Features:
- Introduce separate inference functions for multi-frame and one-frame output models in VapourSynth.

Enhancements:
- Optimize CUDA support for VapourSynth by adding dedicated inference functions for CUDA devices.

Documentation:
- Update README.md to reflect changes in model instantiation and usage.

Chores:
- Fix typo in Makefile by correcting the filename in the vspipe command.